### PR TITLE
Updated model flavours to reflect how to use rtdist

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -1,6 +1,5 @@
 Installation and setup instructions
 ===================================
-
 Requirements
 ------------ 
 
@@ -63,6 +62,8 @@ The steps to install configure and the model are the following:
 
  You will now be be able to call the model identically to any other additive
  model in Xspec.
+
+.. _environmentvars:
 
 Environmental variables
 -----------------------

--- a/source/model_flavours.rst
+++ b/source/model_flavours.rst
@@ -385,7 +385,7 @@ https://ui.adsabs.harvard.edu/abs/2022MNRAS.509..619I/abstract.
     then to xspec.
 
 .. note::
-    :math:`h/r > 0`` is currently not used in the calculation of mu_e and mu_i. 
+    :math:`h/r > 0` is currently not used in the calculation of mu_e and mu_i. 
     These are the cosines of the angles between the incident/emitted ray and 
     the z-axis, NOT the disc normal. This may have implications when inferring
     information about the geometry of the disk.

--- a/source/model_flavours.rst
+++ b/source/model_flavours.rst
@@ -359,8 +359,10 @@ rtdist
 ^^^^^^^^^^^
 
 rtdist is a variant of reltransDCp. It self-consistently calculates the disk
-ionisation by calculating the geometric reltationship between the observer,
-source of illuminating spectrum and the disk. It also features a change to
+ionisation by calculating the geometric relationship between the observer,
+source of illuminating spectrum and the disk, thus logxi is not a parameter 
+of this model flavour, since it has been replaced by the distance between 
+the observer and the source. It also features a change to
 the previous boost normalisation factor for the reflection spectrum. The 
 source is no longer assumed to be isotropic. Instead, the angular
 dependence is specified by the parameters b1, b2 and qboost (referred to as

--- a/source/model_flavours.rst
+++ b/source/model_flavours.rst
@@ -35,9 +35,9 @@ reltransDCp
 ^^^^^^^^^^^
 
 reltransDCp can be considered the "default" version of the lastest reltrans 
-release. It assumes that the disk is illuminated by a nthcomp spectrum and the
-disk is a variable density disk with a fixed high energy cutoff at 300keV. This
-means that it used the xillverDCp tables.
+release. It assumes that the disk is illuminated by an nthcomp spectrum with electron
+temperature kTe, and the disk density is a parameter. This means that it uses the
+xillverDCp tables.
 
 **Parameters:**
 
@@ -130,8 +130,8 @@ reltransPL
 ^^^^^^^^^^^
 
 reltransPL is identical to reltransDCP except that it assumes that the disk is 
-illuminated by a powerlaw spectrum. This means that it used the xillverDCp 
-tables.
+illuminated by an exponentially cut-off powerlaw spectrum, and the disk density
+is hardwired to $10^{15}~cm^{-3}$. This means that it uses the xillver tables.
 
 **Parameters:**
 
@@ -162,42 +162,40 @@ tables.
 | 9                      | Afe        |iron         |
 |                        |            |abundance    |
 +------------------------+------------+-------------+
-| 10                     | logNe      |disk density |
+| 10                     | Ecut       |observed     |
+|                        |            |exponential  |
+|                        |            |cut off      |
+|                        |            |energy       |
 +------------------------+------------+-------------+
-| 11                     | Ecut       |observed     |
-|                        |            |electron     |
-|                        |            |temperature  |
-|                        |            |of the corona|
-+------------------------+------------+-------------+
-| 12                     | nH         |galactic     |
+| 11                     | nH         |galactic     |
 |                        |            |absorption   |
 +------------------------+------------+-------------+
-| 13                     | boost      |reflection   |
+| 12                     | boost      |reflection   |
 |                        |            |spectrum     |
 |                        |            |normalisation|
 +------------------------+------------+-------------+
-| 14                     | Mass       |mass of the  |
+| 13                     | Mass       |mass of the  |
 |                        |            |black hole   |
 +------------------------+------------+-------------+
-| 15                     | fmin       |minimum      |
+| 14                     | fmin       |minimum      |
 |                        |            |frequency of |
 |                        |            |cross        |
 |                        |            |spectrum     |
 +------------------------+------------+-------------+
-| 16                     | fmax       |maximum      |
+| 15                     | fmax       |maximum      |
 |                        |            |frequency of |
 |                        |            |cross        |
 |                        |            |spectrum     |
 +------------------------+------------+-------------+
-| 17                     | ReIm       |flag for     |
+| 16                     | ReIm       |flag for     |
 |                        |            |outputs      |
 +------------------------+------------+-------------+
-| 18                     | phiA       |phase shift  |
+| 17                     | phiA       |phase shift  |
 |                        |            |of the       |
 |                        |            |reference    |
 |                        |            |band         |
 +------------------------+------------+-------------+
-| 19                     | phiAB      |phase        |
+| 18                     | phiAB      |phase        |
 |                        |            |difference   |
 |                        |            |between the  |
 |                        |            |pivoting and |
@@ -206,7 +204,7 @@ tables.
 |                        |            |illuminating |
 |                        |            |variability  |
 +------------------------+------------+-------------+
-| 20                     | g          |ratio of the |
+| 19                     | g          |ratio of the |
 |                        |            |normalisation|
 |                        |            |between the  |
 |                        |            |pivoting and |
@@ -215,7 +213,7 @@ tables.
 |                        |            |illuminating |
 |                        |            |variability  |
 +------------------------+------------+-------------+
-| 21                     | RESP       |the number of|
+| 20                     | RESP       |the number of|
 |                        |            |instrument   |
 |                        |            |responses    |
 |                        |            |used         |
@@ -316,13 +314,13 @@ reltransDbl is identical to reltransDCP except that it assumes that there are
 |                        |            |reference                    |
 |                        |            |band of the bottom lamppost  |
 +------------------------+------------+-----------------------------+
-| 23                     | phiAB      |phase difference             |
+| 23                     | phiAB1     |phase difference             |
 |                        |            |between the pivoting and     |
 |                        |            |normalisation of the         |
 |                        |            |illuminating variability     |
 |                        |            |for the bottom lamppost      |
 +------------------------+------------+-----------------------------+
-| 24                     | g          |ratio of the normalisation   |
+| 24                     | g1         |ratio of the normalisation   |
 |                        |            |between the pivoting and     |
 |                        |            |normalisation of the         |
 |                        |            |illuminating variability     |
@@ -340,15 +338,7 @@ reltransDbl is identical to reltransDCP except that it assumes that there are
 |                        |            |illuminating variability     |
 |                        |            |of the top lamppost          |
 +------------------------+------------+-----------------------------+
-| 27                     | alpha      |Cross-spectral               |
-|                        |            |normalisation                |
-|                        |            |constant                     |
-|                        |            |set to unity                 |
-|                        |            |for                          |
-|                        |            |calculating                  |
-|                        |            |lags                         |
-+------------------------+------------+-----------------------------+
-| 28                     | RESP       |the number of                |
+| 27                     | RESP       |the number of                |
 |                        |            |instrument                   |
 |                        |            |responses                    |
 |                        |            |used                         |
@@ -367,8 +357,8 @@ the previous boost normalisation factor for the reflection spectrum. The
 source is no longer assumed to be isotropic. Instead, the angular
 dependence is specified by the parameters b1, b2 and qboost (referred to as
 as boost but defined differently from other reltrans flavours). b1 and b2 are
-linear and quadratic coefficients of the :math:`\text{mu}= \cos(\theta)` dependence and qboost
-skews the relation where :math:`qboost = \frac{I(\text{mu}=-1)}{I(\text{mu}=1)}`. 
+linear and quadratic coefficients of the :math:`\text{mu}= \cos(\theta)` dependence
+and qboost skews the relation where :math:`qboost = \frac{I(\text{mu}=-1)}{I(\text{mu}=1)}`. 
 The disk scale height also has become a free parameter.
 
 For a comprehensive explanation of the model, please see the model paper:

--- a/source/model_flavours.rst
+++ b/source/model_flavours.rst
@@ -12,6 +12,24 @@ parameters.
     
 Models
 -------
+
+.. note::
+    reltrans is a library of spectral timing models which means that all variants
+    of the model include parameters related to which spectral timing product the 
+    model returns. These include:
+
+    * fmin and fmax: these two parameters define the frequency range of the 
+      cross-spectrum to be evaluated. Setting both of these values to 0 will
+      cause the model to always return the time-averaged spectrum.
+    * ReIm: this parameter flags the model to output different timing products
+      or components of the cross-spectrum. 
+        * 0: The time-averaged spectrum.
+        * 1: Real part of the cross spectrum.
+        * 2: Imaginary part of the cross spectrum.
+        * 3: Modulus of the cross spectrum.
+        * 4: Lag-energy spectrum.
+        * 5: Modulus of the folded cross spectrum.
+        * 6: Lag-energy spectrum calculated from the folded cross spectrum.
     
 reltransDCp
 ^^^^^^^^^^^
@@ -343,9 +361,36 @@ rtdist
 rtdist is a variant of reltransDCp. It self-consistently calculates the disk
 ionisation by calculating the geometric reltationship between the observer,
 source of illuminating spectrum and the disk. It also features a change to
-the previous boost normalisation factor for the reflection spectrum which is 
-changed to 2 emissivity parameters which directs the emission in a 
-manner that is more physical.
+the previous boost normalisation factor for the reflection spectrum. The 
+source is no longer assumed to be isotropic. Instead, the angular
+dependence is specified by the parameters b1, b2 and qboost (referred to as
+as boost but defined differently from other reltrans flavours). b1 and b2 are
+linear and quadratic coefficients of the :math:`\text{mu}= \cos(\theta)` dependence and qboost
+skews the relation where qboost = I(mu=-1)/I(mu=1). The disk scale height
+also has become a free parameter.
+
+For a comprehensive explanation of the model, please see the model paper:
+https://ui.adsabs.harvard.edu/abs/2022MNRAS.509..619I/abstract.
+
+.. note::
+    **IMPORTANT!**
+
+    If you are using rtdist in reltrans, the xspec norm parameter must be frozen
+    to 1 as Anorm replaces xspec norm's function.
+
+    * For the DC component, the xspec norm parameter must be frozen to norm=1.
+    * For the lag spectrum, the xspec norm parameter must (as usual) be frozen to
+      norm=1.
+    * For the Re/Im/amp spectra, the xspec norm becomes the average power in that
+      frequency range in squared fractional rms units (this is the case if the
+      data really is the cross-spectrum and not the complex covariance).
+
+    The reason for this is that Anorm is A0 from the RELTRANS 2.0 paper.
+    Previously, A0 was input as the norm parameter of the DC component. Now we
+    need A0 for all calls because we use it to calculate logxi(r). It is
+    therefore its own model parameter. The model therefore already multiplies
+    the DC component by Anorm and the AC components by Anorm^2  before sending
+    then to xspec.
 
 **Parameters:**
 
@@ -373,25 +418,26 @@ manner that is more physical.
 | 8                      | Dkpc       |Distance to  |
 |                        |            |source in kpc|
 +------------------------+------------+-------------+
-| 9                      | logxi      |ionisation   |
-+------------------------+------------+-------------+
-| 10                     | Afe        |iron         |
+| 9                      | Afe        |iron         |
 |                        |            |abundance    |
 +------------------------+------------+-------------+
-| 11                     | logNe      |disk density |
+| 10                     | logNe      |disk density |
 +------------------------+------------+-------------+
-| 12                     | kTe        |electron     |
+| 11                     | kTe        |electron     |
 |                        |            |temperature  |
 |                        |            |of the corona|
 +------------------------+------------+-------------+
-| 13                     | nH         |galactic     |
+| 12                     | nH         |galactic     |
 |                        |            |absorption   |
 +------------------------+------------+-------------+
-| 14                     | boost      |reflection   |
+| 13                     | boost      |reflection   |
 |                        |            |spectrum     |
 |                        |            |normalisation|
 +------------------------+------------+-------------+
-| 15                     | Mass       |mass of the  |
+| 14                     | honr       |scale height |
+|                        |            |of the disk  |
++------------------------+------------+-------------+
+| 14                     | Mass       |mass of the  |
 |                        |            |black hole   |
 +------------------------+------------+-------------+
 | 16                     | b1         |emissivity   |

--- a/source/model_flavours.rst
+++ b/source/model_flavours.rst
@@ -368,8 +368,8 @@ source is no longer assumed to be isotropic. Instead, the angular
 dependence is specified by the parameters b1, b2 and qboost (referred to as
 as boost but defined differently from other reltrans flavours). b1 and b2 are
 linear and quadratic coefficients of the :math:`\text{mu}= \cos(\theta)` dependence and qboost
-skews the relation where qboost = I(mu=-1)/I(mu=1). The disk scale height
-also has become a free parameter.
+skews the relation where :math:`qboost = \frac{I(\text{mu}=-1)}{I(\text{mu}=1)}`. 
+The disk scale height also has become a free parameter.
 
 For a comprehensive explanation of the model, please see the model paper:
 https://ui.adsabs.harvard.edu/abs/2022MNRAS.509..619I/abstract.
@@ -500,8 +500,9 @@ Simulators
 We also include a number of simulators for the different reltrans model
 flavours. These are explicitly for simulating the timing products that reltrans
 computes. This results in additional coherence, rms variability and time
-exposure parameters. See :ref: 'environment'. There is no simulator for the 
-reltransPL.
+exposure parameters. See :ref:`environmentvars` for additional parameters 
+pertaining to the simulation such as seeding the simulation. There is no 
+simulator for the reltransPL.
 
 simrelt
 ^^^^^^^

--- a/source/model_flavours.rst
+++ b/source/model_flavours.rst
@@ -394,6 +394,12 @@ https://ui.adsabs.harvard.edu/abs/2022MNRAS.509..619I/abstract.
     the DC component by Anorm and the AC components by Anorm^2  before sending
     then to xspec.
 
+.. note::
+    :math:`h/r > 0`` is currently not used in the calculation of mu_e and mu_i. 
+    These are the cosines of the angles between the incident/emitted ray and 
+    the z-axis, NOT the disc normal. This may have implications when inferring
+    information about the geometry of the disk.
+
 **Parameters:**
 
 +------------------------+------------+-------------+


### PR DESCRIPTION
Relates to reltrans/reltrans/pull/49 by making sure that the rtdist_notes file is properly reflected in model flavours in the docs.

This also slightly expands on the documentation of ReIm, by properly explaining in a note how inputting the parameter will change the output of reltrans models.