### PR TITLE
Remove xillverD-5.fits table from the documentation

### DIFF
--- a/source/installation.rst
+++ b/source/installation.rst
@@ -15,8 +15,8 @@ The following are required:
 
 * (Normalised) `XILLVER tables <https://sites.srl.caltech.edu/~javier/xillver/>`_.
 
-  In particular, ``xillverCp_v3.4.fits``, ``xilverD-5.fits`` and
-  ``xilver-a-Ec5.fits``. These can either be normalised yourself using a
+  In particular, ``xillverCp_v3.4.fits`` and ``xilver-a-Ec5.fits``.
+  These can either be normalised yourself using a
   provided script (detailed below), or you can use the pre-normalised tables
   from `our test suite
   <https://github.com/reltrans/model-data/releases/latest>`_ (Note: these are


### PR DESCRIPTION
We removed the possibility to call reltransPL (powerlaw illumination) with the variable density parameter, since the xillver tables with high density values had the electron energy cut off fixed to 300keV