### PR TITLE
Fix #7: Add self to toctree so homepage appears in sidebar

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -28,6 +28,7 @@ Documentation contents
 .. toctree::
    :maxdepth: 1
    
+   self
    installation 
    model_flavours
 


### PR DESCRIPTION
Fixes #7

Added self to the toctree directive in source/index.rst so the splash page appears in the sidebar navigation.
Before: Users could only reach the homepage by clicking the Reltrans logo at the top.
After: Homepage now appears directly in the sidebar as "Welcome to Reltrans's documentation!"
Known limitations:
1) The homepage link only appears in the sidebar when on the homepage itself. On other pages (e.g. Installation), the link disappears. This is default Sphinx behavior with self in toctree.
2) The sidebar label shows the full page title "Welcome to Reltrans's documentation!" rather than a shorter label like "Home" — this is also a Sphinx limitation with self.

A more complete fix would likely require modifying the global navigation configuration or the Sphinx theme settings, which is beyond the scope of this simple change. I'm happy to collaborate with the mentors on a more complete solution if needed!
!
<img width="2802" height="1510" alt="reltrans_sidebar" src="https://github.com/user-attachments/assets/647127b8-331c-4ac4-bb9c-a6ed459f6dab" />

